### PR TITLE
Move the semanctics URL to the new project repository on GitHub

### DIFF
--- a/etc/glite-info-glue2-bdii-site.conf.template
+++ b/etc/glite-info-glue2-bdii-site.conf.template
@@ -48,7 +48,8 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.
 # This should be a unix timestamp, the info provider converts it to ISO8601

--- a/etc/glite-info-glue2-bdii-site.conf.template
+++ b/etc/glite-info-glue2-bdii-site.conf.template
@@ -48,7 +48,6 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
 semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.

--- a/etc/glite-info-glue2-bdii-top.conf.template
+++ b/etc/glite-info-glue2-bdii-top.conf.template
@@ -48,7 +48,8 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.
 # This should be a unix timestamp, the info provider converts it to ISO8601

--- a/etc/glite-info-glue2-bdii-top.conf.template
+++ b/etc/glite-info-glue2-bdii-top.conf.template
@@ -48,7 +48,6 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
 semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.

--- a/etc/glite-info-service-bdii-site.conf.template
+++ b/etc/glite-info-service-bdii-site.conf.template
@@ -46,7 +46,8 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.
 # This should be a unix timestamp, the info provider converts it to ISO8601

--- a/etc/glite-info-service-bdii-site.conf.template
+++ b/etc/glite-info-service-bdii-site.conf.template
@@ -46,7 +46,6 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
 semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.

--- a/etc/glite-info-service-bdii-top.conf.template
+++ b/etc/glite-info-service-bdii-top.conf.template
@@ -46,7 +46,8 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
+semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.
 # This should be a unix timestamp, the info provider converts it to ISO8601

--- a/etc/glite-info-service-bdii-top.conf.template
+++ b/etc/glite-info-service-bdii-top.conf.template
@@ -46,7 +46,6 @@ WSDL_URL = nohttp://not.a.web.service/
 # If the string does not start with "http" this will be omitted
 
 #semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
-#semantics_URL = https://tomtools.cern.ch/confluence/display/IS/Home
 semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.

--- a/etc/glite-info-service-bdii.conf.template
+++ b/etc/glite-info-service-bdii.conf.template
@@ -43,7 +43,8 @@ WSDL_URL = nohttp://not.a.web.service/
 # A URL to a web page defining the service semantics, e.g. a manual
 # If the string does not start with "http" this will be omitted
 
-semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
+#semantics_URL = https://twiki.cern.ch/twiki/bin/view/EGEE/BDII
+semantics_URL = https://github.com/EGI-Federation/bdii
 
 # StartTime: A command to return the service start time.
 # This should be a unix timestamp, the info provider converts it to ISO8601


### PR DESCRIPTION
# Summary

The current semantics URL point to old web pages. This PR contains updates for the BDII (it point now to the current  EGI-Federation repository hosted on GitHub).