### PR TITLE
Fix the service status when using systemd

### DIFF
--- a/etc/glite-info-service-bdii-site.conf.template
+++ b/etc/glite-info-service-bdii-site.conf.template
@@ -35,7 +35,7 @@ get_endpoint = echo ldap://$BDII_HOST:$BDII_PORT_READ/mds-vo-name=$GLITE_INFO_SE
 # The return code should indicate the status:
 # 0 = OK, 1 = Critical, 2 = Warning, 3 = Unknown, other = Other
 
-get_status = glite-info-service-test BDII && /sbin/service bdii status
+get_status = glite-info-service-test BDII && glite-info-service-status bdii
 
 # The URL of a WSDL document describing the service
 # If the string does not start with "http" this will be omitted

--- a/etc/glite-info-service-bdii-top.conf.template
+++ b/etc/glite-info-service-bdii-top.conf.template
@@ -35,7 +35,7 @@ get_endpoint = echo ldap://$BDII_HOST:$BDII_PORT_READ/mds-vo-name=local,o=grid
 # The return code should indicate the status:
 # 0 = OK, 1 = Critical, 2 = Warning, 3 = Unknown, other = Other
 
-get_status = glite-info-service-test BDII && /sbin/service bdii status
+get_status = glite-info-service-test BDII && glite-info-service-status bdii
 
 # The URL of a WSDL document describing the service
 # If the string does not start with "http" this will be omitted

--- a/etc/glite-info-service-bdii.conf.template
+++ b/etc/glite-info-service-bdii.conf.template
@@ -33,7 +33,7 @@ get_endpoint = echo ldap://$BDII_HOST:$BDII_PORT_READ/$BDII_BIND
 # The return code should indicate the status:
 # 0 = OK, 1 = Critical, 2 = Warning, 3 = Unknown, other = Other
 
-get_status = glite-info-service-test BDII && /sbin/service bdii status
+get_status = glite-info-service-test BDII && glite-info-service-status bdii
 
 # The URL of a WSDL document describing the service
 # If the string does not start with "http" this will be omitted

--- a/src/glite-info-service-status
+++ b/src/glite-info-service-status
@@ -18,7 +18,7 @@ shift
 export LANG=C
 
 # Collect the stdout and return code from service status
-string=$(/sbin/service "$service" status "$@")
+string=$(/usr/bin/systemctl is-active "${service}")
 rc=$?
 
 # Strip out the standard representation of pids


### PR DESCRIPTION
# Summary

When using BDII on Alma 9, the reported GlueServiceStatusInfo value is `??`, as the code is using service command instead of systemctl. However, since CentOS 7, systemd is used by default. The following PR permits to report correctly the value of status:
 ```
$ glite-info-service-status bdii
active
```