### PR TITLE
chore: preapre for 1.15.0.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.15.0] - 2025-01-24
+
+## Fixed
+
+- Move the semantics URL to the new project repository on GitHub (#14) (Jérôme Pansanel)
+- Fix the service status when using systemd (#15) (Jérôme Pansanel)
+
+## Removed
+
+- Remove support for CentOS 7 (#16) (Baptiste Grenier)
+
 ## [1.14.2] - 2024-06-28
 
 ## Fixed

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+glue-service-provider (1.15.0-1) UNRELEASED; urgency=low
+
+  * Move the semantics URL to the new project repository on GitHub (#14) (Jérôme Pansanel)
+  * Fix the service status when using systemd (#15) (Jérôme Pansanel)
+  * Remove support for CentOS 7 (#16) (Baptiste Grenier)
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu>  Fri, 24 Jan 2025 17:47:00 +0100
+
 glue-service-provider (1.14.0-1) UNRELEASED; urgency=low
 
   * Drop some deprecated providers (gatekeeper, gridice, lbserver, wmproxy). (#3) (Baptiste Grenier)

--- a/glite-info-provider-service.spec
+++ b/glite-info-provider-service.spec
@@ -1,5 +1,5 @@
 Name:          glite-info-provider-service
-Version:       1.14.2
+Version:       1.15.0
 Release:       1%{?dist}
 Summary:       The GLUE service information provider
 Group:         Development/Libraries
@@ -115,6 +115,11 @@ rm -rf %{buildroot}
 %license %{_datadir}/licenses/%{name}-%{version}/LICENSE.txt
 
 %changelog
+* Fri Jan 24 2025 Baptiste Grenier <baptiste.grenier@egi.eu> - 1.15.0-1
+- Move the semantics URL to the new project repository on GitHub (#14) (Jérôme Pansanel)
+- Fix the service status when using systemd (#15) (Jérôme Pansanel)
+- Remove support for CentOS 7 (#16) (Baptiste Grenier)
+
 * Tue Apr 28 2024 Baptiste Grenier <baptiste.grenier@egi.eu> - 1.14.2-1
 - Add missing dependency on lsb_release. (#11) (Baptiste Grenier)
 


### PR DESCRIPTION
## [1.15.0] - 2025-01-24

## Fixed

- Move the semantics URL to the new project repository on GitHub (#14) (Jérôme Pansanel)
- Fix the service status when using systemd (#15) (Jérôme Pansanel)

## Removed

- Remove support for CentOS 7 (#16) (Baptiste Grenier)